### PR TITLE
fix: detect ci build domain for testing

### DIFF
--- a/src/sidekick/app.js
+++ b/src/sidekick/app.js
@@ -1376,7 +1376,7 @@
         let configOrigin = '';
         if (devMode) {
           configOrigin = DEV_URL.origin;
-        } else if (!new RegExp(`${repo}\\-\\-${owner}\\.hlx3?\\.page$`).test(window.location.hostname)) {
+        } else if (!new RegExp(`${repo}\\-\\-${owner}\\.hlx(\\-\\d|3)?\\.page$`).test(window.location.hostname)) {
           // load config from inner CDN
           configOrigin = `https://${ref}--${repo}--${owner}.hlx.page`;
         }


### PR DESCRIPTION
Fix #67 

This will make the currently failing `theblog-tests` pass.