### PR TITLE
Default check 'helix 3' checkbox in extension config

### DIFF
--- a/src/extension/options.html
+++ b/src/extension/options.html
@@ -23,7 +23,7 @@ governing permissions and limitations under the License.
         <p class="mandatory"><input id="edit-giturl"></p>
         <p class="mandatory"><input id="edit-mountpoints"></p>
         <p><input id="edit-host"></p>
-        <p><input id="edit-hlx3" type="checkbox"> Helix 3</p>
+        <p><input id="edit-hlx3" type="checkbox" checked> Helix 3</p>
         <p>
           <button></button>
           <button></button>


### PR DESCRIPTION
By default, the helix 3 checkbox is unselected, which leads to hlx.page instead of hlx3.page preview/live urls.
I overlooked that checkbox while adding my sidekick config and it took me quite a while to notice the missing 3 in each url.

Since helix2 is **deprecated** anyways, I think that helix 3 checkbox should be preselected.