### PR TITLE
fix: preserve query params and hash when switching env

### DIFF
--- a/src/sidekick/module.js
+++ b/src/sidekick/module.js
@@ -1402,14 +1402,14 @@
       if (this.status.error) {
         return this;
       }
-      const { config, location: { href, search }, status } = this;
+      const { config, location: { href, search, hash }, status } = this;
       this.showModal('Please wait …', true);
       if (!status.webPath) {
         console.log('not ready yet, trying again in a second ...');
         window.setTimeout(() => this.switchEnv(targetEnv, open), 1000);
         return this;
       }
-      const envUrl = `https://${config[hostType]}${status.webPath}${search}`;
+      const envUrl = `https://${config[hostType]}${status.webPath}${search}${hash}`;
       if (config.hlx3 && targetEnv === 'preview' && this.isEditor()) {
         await this.update();
       }

--- a/src/sidekick/module.js
+++ b/src/sidekick/module.js
@@ -1402,19 +1402,19 @@
       if (this.status.error) {
         return this;
       }
-      const { config, location, status } = this;
+      const { config, location: { href, search }, status } = this;
       this.showModal('Please wait …', true);
       if (!status.webPath) {
         console.log('not ready yet, trying again in a second ...');
         window.setTimeout(() => this.switchEnv(targetEnv, open), 1000);
         return this;
       }
-      const envUrl = `https://${config[hostType]}${status.webPath}`;
+      const envUrl = `https://${config[hostType]}${status.webPath}${search}`;
       if (config.hlx3 && targetEnv === 'preview' && this.isEditor()) {
         await this.update();
       }
       fireEvent(this, 'envswitched', {
-        sourceUrl: location.href,
+        sourceUrl: href,
         targetUrl: envUrl,
       });
       // switch or open env

--- a/test/fixtures/preserve-query-params.html
+++ b/test/fixtures/preserve-query-params.html
@@ -1,0 +1,14 @@
+<html>
+  <head>
+    <meta charset="utf-8"/>
+  </head>
+  <body>
+    <!-- preserve query params and hash -->
+    <input type="hidden" id="sidekick_test_location" value="https://main--pages--adobe.hlx.live/creativecloud/en/test?foo=bar"/>
+    <script
+      id='hlx-sk-test'
+      src='./bookmarklet.js'
+      data-config='{"owner":"adobe","repo":"pages","ref":"main","hlx3":true}'
+    ></script>
+  </body>
+</html>

--- a/test/preview.test.js
+++ b/test/preview.test.js
@@ -129,4 +129,29 @@ describe('Test preview plugin', () => {
       plugin: 'preview',
     });
   }).timeout(IT_DEFAULT_TIMEOUT);
+
+  it('Preview plugin preserves query parameters and hash when switching to preview', async () => {
+    const page = getPage();
+    const apiMock = MOCKS.api.pages;
+    await testPageRequests({
+      page,
+      url: `${fixturesPrefix}/preserve-query-params.html`,
+      check: (req) => {
+        if (req.url().includes('main--pages--adobe.hlx3.page')) {
+          // check query params in request to preview url
+          assert.ok(
+            req.url() === `https://main--pages--adobe.hlx3.page${apiMock.webPath}?foo=bar`,
+            'Query parameters and hash not preserved',
+          );
+          return true;
+        }
+        // ignore otherwise
+        return false;
+      },
+      mockResponses: [
+        apiMock,
+      ],
+      plugin: 'preview',
+    });
+  }).timeout(IT_DEFAULT_TIMEOUT);
 });


### PR DESCRIPTION
Fix #139 