### PR TITLE
fix: limit image size in json view

### DIFF
--- a/src/sidekick/app.css
+++ b/src/sidekick/app.css
@@ -378,6 +378,7 @@
 
 .hlx-sk-special-view table td > div img {
   width: 100%;
+  max-width: 240px;
 }
 
 .hlx-sk-special-view table td > div ul {


### PR DESCRIPTION
Images can run wide in tables with less columns, so we should impose a width limit.