### PR TITLE
fix: modal width regression

### DIFF
--- a/src/sidekick/app.css
+++ b/src/sidekick/app.css
@@ -235,8 +235,7 @@
   font-size: var(--hlx-sk-modal-font-size);
   border-radius: 32px;
   padding: 12px 32px;
-  width: 60vw;
-  max-width: 800px;
+  max-width: 60vw;
   background-color: var(--hlx-sk-bg);
   color: var(--hlx-sk-color);
   box-shadow: var(--hlx-sk-shadow);


### PR DESCRIPTION
Shorter messages should not span the modal to 60% screen width:
![image](https://user-images.githubusercontent.com/1609742/152191685-a00edf66-0db6-40e3-9ff3-3291270c42bb.png)
