### PR TITLE
fix: revert general border radius to 32 and only use smaller radius on help modal

### DIFF
--- a/src/sidekick/app.css
+++ b/src/sidekick/app.css
@@ -344,7 +344,7 @@
 .hlx-sk-overlay .modal {
   font-family: var(--hlx-sk-font-family);
   font-size: var(--hlx-sk-modal-font-size);
-  border-radius: 4px;
+  border-radius: 32px;
   padding: 12px 32px;
   max-width: 60vw;
   background-color: var(--hlx-sk-bg);
@@ -374,6 +374,7 @@
 .hlx-sk-overlay .modal.help {
   margin-top: 15px;
   position: absolute;
+  border-radius: 4px;
   padding: 12px 24px;
   background-color: var(--hlx-sk-modal-help-bg);
   color: var(--hlx-sk-modal-help-color);


### PR DESCRIPTION
As discussed, didn't realize I changed the border radius for the `working` modal (preview/publish etc). This reverts that change and only updates the radius for the help modal. 