### PR TITLE
fix(regression): more robust host matching

### DIFF
--- a/src/sidekick/module.js
+++ b/src/sidekick/module.js
@@ -252,11 +252,12 @@
    * @private
    * @param {string} host The host name
    * @returns {string[]} The project details
+   * @throws {Error} if host is not a Helix host
    */
   function getHelixProjectDetails(host) {
     const details = host.split('.')[0].split('--');
     if (details.length < 2) {
-      return false;
+      throw new Error('not a helix host');
     }
     if (details.length === 3) {
       // lose ref
@@ -287,9 +288,14 @@
       return false;
     }
     // project details
-    const [baseHostRepo, baseHostOwner] = getHelixProjectDetails(baseHost);
-    const [hostRepo, hostOwner] = getHelixProjectDetails(host);
-    return baseHostOwner === hostOwner && baseHostRepo === hostRepo;
+    try {
+      const [baseHostRepo, baseHostOwner] = getHelixProjectDetails(baseHost);
+      const [hostRepo, hostOwner] = getHelixProjectDetails(host);
+      return baseHostOwner === hostOwner && baseHostRepo === hostRepo;
+    } catch (e) {
+      // ignore if no helix host
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
Fixes an error where `getHelixProjectDetails` returns the wrong type of object when comparing a Helix host against a non-Helix host (e.g. production):
```
Uncaught TypeError: getHelixProjectDetails is not a function or its return value is not iterable
    at matchHelixHost (module.js:291:35)
    at HTMLElement.isOuter (module.js:1663:14)
    at HTMLElement.isHelix (module.js:1681:52)
    at Object.condition (module.js:735:65)
    at HTMLElement.add (module.js:1480:64)
    at addEditPlugin (module.js:733:8)
    at HTMLDivElement.contextloaded (module.js:1260:13)
    at fireEvent (module.js:653:15)
    at HTMLElement.loadContext (module.js:1402:7)
    at new Sidekick (module.js:1322:12)
```