### PR TITLE
Show `x-error` response header when config change fails

### DIFF
--- a/src/sidekick/app.css
+++ b/src/sidekick/app.css
@@ -907,6 +907,10 @@
   content: "Helix configuration successfully activated.";
 }
 
+.hlx-sk-overlay .modal.modal-config-failure::before {
+  content: "Failed to activate Helix configuration: ";
+}
+
 .hlx-sk-overlay .modal.modal-preview-failure::before {
   content: "Previewing failed. Please try again later.";
 }

--- a/src/sidekick/de.css
+++ b/src/sidekick/de.css
@@ -147,7 +147,11 @@
 }
 
 .hlx-sk-overlay .modal.modal-config-success::before {
-  content: "Helix-Konnfiguration erfolgreich aktiviert.";
+  content: "Helix-Konfiguration erfolgreich aktiviert.";
+}
+
+.hlx-sk-overlay .modal.modal-config-failure::before {
+  content: "Aktivierung der Helix-Konfiguration fehlgeschlagen: ";
 }
 
 .hlx-sk-overlay .modal.modal-preview-failure::before {

--- a/src/sidekick/fr.css
+++ b/src/sidekick/fr.css
@@ -150,6 +150,10 @@
   content: "La configuration a été activée.";
 }
 
+.hlx-sk-overlay .modal.modal-config-failure::before {
+  content: "L'activation de la configuration a échoué: ";
+}
+
 .hlx-sk-overlay .modal.modal-preview-failure::before {
   content: "La génération de l'aperçu a échoué. Veuillez essayer plus tard.";
 }

--- a/src/sidekick/module.js
+++ b/src/sidekick/module.js
@@ -891,15 +891,6 @@
           sk.showWait();
           // update preview
           const resp = await sk.update();
-          if (!resp.ok) {
-            console.error(resp);
-            sk.showModal({
-              css: 'modal-preview-failure',
-              sticky: true,
-              level: 0,
-            });
-            return;
-          }
           // handle special case /.helix/*
           if (status.webPath.startsWith('/.helix/')) {
             if (!resp.ok) {
@@ -913,6 +904,15 @@
                 css: 'modal-config-success',
               });
             }
+            return;
+          }
+          if (!resp.ok) {
+            console.error(resp);
+            sk.showModal({
+              css: 'modal-preview-failure',
+              sticky: true,
+              level: 0,
+            });
             return;
           }
           sk.switchEnv('preview', newTab(evt));

--- a/src/sidekick/module.js
+++ b/src/sidekick/module.js
@@ -895,7 +895,7 @@
             if (status.webPath.startsWith('/.helix/') && resp.error) {
               // show detail message only in power-user mode
               sk.showModal({
-                message: `Previewing failed. ${resp.error}`,
+                message: `Unable to activate Helix configuration: ${resp.error}`,
                 sticky: true,
                 level: 0,
               });

--- a/src/sidekick/module.js
+++ b/src/sidekick/module.js
@@ -894,7 +894,6 @@
           if (!resp.ok) {
             console.error(resp);
             sk.showModal({
-              message: resp.error,
               css: 'modal-preview-failure',
               sticky: true,
               level: 0,
@@ -903,9 +902,17 @@
           }
           // handle special case /.helix/*
           if (status.webPath.startsWith('/.helix/')) {
-            sk.showModal({
-              css: 'modal-config-success',
-            });
+            if (!resp.ok) {
+              sk.showModal({
+                message: resp.error,
+                sticky: true,
+                level: 0,
+              });
+            } else {
+              sk.showModal({
+                css: 'modal-config-success',
+              });
+            }
             return;
           }
           sk.switchEnv('preview', newTab(evt));

--- a/src/sidekick/module.js
+++ b/src/sidekick/module.js
@@ -894,6 +894,7 @@
           if (!resp.ok) {
             console.error(resp);
             sk.showModal({
+              message: resp.error,
               css: 'modal-preview-failure',
               sticky: true,
               level: 0,
@@ -2417,6 +2418,7 @@
       return {
         ok: (resp && resp.ok) || false,
         status: (resp && resp.status) || 0,
+        error: (resp && resp.headers.get('x-error')) || '',
         path,
       };
     }

--- a/src/sidekick/module.js
+++ b/src/sidekick/module.js
@@ -895,7 +895,7 @@
             if (status.webPath.startsWith('/.helix/') && resp.error) {
               // show detail message only in power-user mode
               sk.showModal({
-                message: resp.error,
+                message: `Previewing failed. ${resp.error}`,
                 sticky: true,
                 level: 0,
               });

--- a/src/sidekick/module.js
+++ b/src/sidekick/module.js
@@ -893,7 +893,7 @@
           const resp = await sk.update();
           if (!resp.ok) {
             if (status.webPath.startsWith('/.helix/') && resp.error) {
-              // show detail message only in power-user mode
+              // show detail message only in config update mode
               sk.showModal({
                 message: `Unable to activate Helix configuration: ${resp.error}`,
                 sticky: true,

--- a/src/sidekick/module.js
+++ b/src/sidekick/module.js
@@ -891,27 +891,28 @@
           sk.showWait();
           // update preview
           const resp = await sk.update();
-          // handle special case /.helix/*
-          if (status.webPath.startsWith('/.helix/')) {
-            if (!resp.ok) {
+          if (!resp.ok) {
+            if (status.webPath.startsWith('/.helix/') && resp.error) {
+              // show detail message only in power-user mode
               sk.showModal({
                 message: resp.error,
                 sticky: true,
                 level: 0,
               });
             } else {
+              console.error(resp);
               sk.showModal({
-                css: 'modal-config-success',
+                css: 'modal-preview-failure',
+                sticky: true,
+                level: 0,
               });
             }
             return;
           }
-          if (!resp.ok) {
-            console.error(resp);
+          // handle special case /.helix/*
+          if (status.webPath.startsWith('/.helix/')) {
             sk.showModal({
-              css: 'modal-preview-failure',
-              sticky: true,
-              level: 0,
+              css: 'modal-config-success',
             });
             return;
           }

--- a/src/sidekick/module.js
+++ b/src/sidekick/module.js
@@ -895,7 +895,8 @@
             if (status.webPath.startsWith('/.helix/') && resp.error) {
               // show detail message only in config update mode
               sk.showModal({
-                message: `Unable to activate Helix configuration: ${resp.error}`,
+                css: 'modal-config-failure',
+                message: resp.error,
                 sticky: true,
                 level: 0,
               });

--- a/test/preview.test.js
+++ b/test/preview.test.js
@@ -130,6 +130,25 @@ describe('Test preview plugin', () => {
     assert.ok(notification.className.includes('modal-config-success'), `Unexpected notification classes: ${notification.className}`);
   }).timeout(IT_DEFAULT_TIMEOUT);
 
+  it('Edit-specific preview plugin handles /.helix/* error message from server', async () => {
+    const test = new SidekickTest({
+      url: 'https://adobe.sharepoint.com/:x:/r/sites/TheBlog/_layouts/15/Doc.aspx?sourcedoc=%7BE8EC80CB-24C3-4B95-B082-C51FD8BC8760%7D&file=test.xlsx&action=default&mobileredirect=true',
+      type: 'json',
+      plugin: 'edit-preview',
+    });
+    test.apiResponses[0].webPath = '/.helix/test.json';
+    test.apiResponses[1] = {
+      status: 502,
+      body: 'Bad Gateway',
+      headers: {
+        'x-error': 'foo',
+      },
+    };
+    const { popupOpened, notification } = await test.run();
+    assert.ok(!popupOpened, 'Unexpected popup opened');
+    assert.strictEqual(notification.message, 'Previewing failed. foo', `Unexpected notification message: ${notification.message}`);
+  }).timeout(IT_DEFAULT_TIMEOUT);
+
   it('Edit-specific preview plugin shows update indicator if edit is newer than preview', async () => {
     const test = new SidekickTest({
       url: 'https://adobe.sharepoint.com/:w:/r/sites/TheBlog/_layouts/15/Doc.aspx?sourcedoc=%7BE8EC80CB-24C3-4B95-B082-C51FD8BC8760%7D&file=bla.docx&action=default&mobileredirect=true',

--- a/test/preview.test.js
+++ b/test/preview.test.js
@@ -130,7 +130,7 @@ describe('Test preview plugin', () => {
     assert.ok(notification.className.includes('modal-config-success'), `Unexpected notification classes: ${notification.className}`);
   }).timeout(IT_DEFAULT_TIMEOUT);
 
-  it.only('Edit-specific preview plugin shows /.helix/* error message from server', async () => {
+  it('Edit-specific preview plugin shows /.helix/* error message from server', async () => {
     const test = new SidekickTest({
       url: 'https://adobe.sharepoint.com/:x:/r/sites/TheBlog/_layouts/15/Doc.aspx?sourcedoc=%7BE8EC80CB-24C3-4B95-B082-C51FD8BC8760%7D&file=test.xlsx&action=default&mobileredirect=true',
       type: 'json',

--- a/test/preview.test.js
+++ b/test/preview.test.js
@@ -101,7 +101,7 @@ describe('Test preview plugin', () => {
 
   it('Edit-specific preview plugin updates preview when switching from editor', async () => {
     const { requestsMade } = await new SidekickTest({
-      url: 'https://adobe.sharepoint.com/:w:/r/sites/TheBlog/_layouts/15/Doc.aspx?sourcedoc=%7BE8EC80CB-24C3-4B95-B082-C51FD8BC8760%7D&file=bla.docx&action=default&mobileredirect=true',
+      url: 'https://adobe.sharepoint.com/:x:/r/sites/TheBlog/_layouts/15/Doc.aspx?sourcedoc=%7BE8EC80CB-24C3-4B95-B082-C51FD8BC8760%7D&file=bla.docx&action=default&mobileredirect=true',
       plugin: 'edit-preview',
     }).run();
     const updateReq = requestsMade
@@ -130,7 +130,7 @@ describe('Test preview plugin', () => {
     assert.ok(notification.className.includes('modal-config-success'), `Unexpected notification classes: ${notification.className}`);
   }).timeout(IT_DEFAULT_TIMEOUT);
 
-  it('Edit-specific preview plugin handles /.helix/* error message from server', async () => {
+  it.only('Edit-specific preview plugin shows /.helix/* error message from server', async () => {
     const test = new SidekickTest({
       url: 'https://adobe.sharepoint.com/:x:/r/sites/TheBlog/_layouts/15/Doc.aspx?sourcedoc=%7BE8EC80CB-24C3-4B95-B082-C51FD8BC8760%7D&file=test.xlsx&action=default&mobileredirect=true',
       type: 'json',
@@ -146,7 +146,7 @@ describe('Test preview plugin', () => {
     };
     const { popupOpened, notification } = await test.run();
     assert.ok(!popupOpened, 'Unexpected popup opened');
-    assert.strictEqual(notification.message, 'Previewing failed. foo', `Unexpected notification message: ${notification.message}`);
+    assert.strictEqual(notification.message, 'foo', `Unexpected notification message: ${notification.message}`);
   }).timeout(IT_DEFAULT_TIMEOUT);
 
   it('Edit-specific preview plugin shows update indicator if edit is newer than preview', async () => {


### PR DESCRIPTION
Now looks as follows:

<img width="1133" alt="Screen Shot 2022-06-01 at 08 18 11" src="https://user-images.githubusercontent.com/22323322/171340265-cf5f4aa2-ea49-4c1e-a81b-3b4c6f3b65c3.png">
